### PR TITLE
Add Categorical Likelihood

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,9 +8,11 @@ AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c" 
 
 [compat]
 AbstractGPs = "0.2"
 Distributions = "0.19, 0.20, 0.21, 0.22, 0.23"
 Functors = "0.1"
+StatsFuns = "0.9"
 julia = "1.3"

--- a/src/GPLikelihoods.jl
+++ b/src/GPLikelihoods.jl
@@ -4,12 +4,14 @@ using Distributions
 using AbstractGPs
 using Random
 using Functors
+using StatsFuns: logistic, softmax
 
 import Distributions
 
-export GaussianLikelihood, PoissonLikelihood
+export CategoricalLikelihood, GaussianLikelihood, PoissonLikelihood
 
 # Likelihoods
+include("likelihoods/categorical.jl")
 include("likelihoods/gaussian.jl")
 include("likelihoods/poisson.jl")
 

--- a/src/likelihoods/categorical.jl
+++ b/src/likelihoods/categorical.jl
@@ -1,0 +1,18 @@
+
+"""
+    CategoricalLikelihood
+
+Categorical likelihood is to be used if we assume that the 
+uncertainity associated with the data follows a Categorical distribution.
+```math
+    p(y|f_1, f_2, \\dots, f_n) = Categorical(y | f_1, f_2, \\dots, f_n)
+```
+On calling, this would return a Categorical distribution with `f` probability of `true`.
+"""
+struct CategoricalLikelihood end
+
+@functor CategoricalLikelihood
+
+(l::CategoricalLikelihood)(f::AbstractVector{<:Real}) = Categorical(softmax(f))
+
+(l::CategoricalLikelihood)(fs::AbstractVector) = Product(Categorical.(softmax.(fs)))

--- a/src/likelihoods/categorical.jl
+++ b/src/likelihoods/categorical.jl
@@ -7,7 +7,8 @@ uncertainity associated with the data follows a Categorical distribution.
 ```math
     p(y|f_1, f_2, \\dots, f_n) = Categorical(y | f_1, f_2, \\dots, f_n)
 ```
-On calling, this would return a Categorical distribution with `f` probability of `true`.
+On calling, this would return a Categorical distribution with `f_i` 
+probability of `i` category.
 """
 struct CategoricalLikelihood end
 

--- a/src/likelihoods/categorical.jl
+++ b/src/likelihoods/categorical.jl
@@ -11,6 +11,6 @@ probability of `i` category.
 """
 struct CategoricalLikelihood end
 
-(l::CategoricalLikelihood)(f::AbstractVector{<:Real}) = Categorical(softmax(append!(f, 0)))
+(l::CategoricalLikelihood)(f::AbstractVector{<:Real}) = Categorical(softmax(vcat(f, 0)))
 
-(l::CategoricalLikelihood)(fs::AbstractVector) = Product(Categorical.(softmax.(append!.(fs, 0))))
+(l::CategoricalLikelihood)(fs::AbstractVector) = Product(Categorical.(softmax.(vcat.(fs, 0))))

--- a/src/likelihoods/categorical.jl
+++ b/src/likelihoods/categorical.jl
@@ -1,18 +1,15 @@
-
 """
     CategoricalLikelihood
 
 Categorical likelihood is to be used if we assume that the 
 uncertainity associated with the data follows a Categorical distribution.
 ```math
-    p(y|f_1, f_2, \\dots, f_n) = Categorical(y | f_1, f_2, \\dots, f_n)
+    p(y|f_1, f_2, \\dots, f_n) = Categorical(y | softmax(f_1, f_2, \\dots, f_n))
 ```
 On calling, this would return a Categorical distribution with `f_i` 
 probability of `i` category.
 """
 struct CategoricalLikelihood end
-
-@functor CategoricalLikelihood
 
 (l::CategoricalLikelihood)(f::AbstractVector{<:Real}) = Categorical(softmax(f))
 

--- a/src/likelihoods/categorical.jl
+++ b/src/likelihoods/categorical.jl
@@ -4,13 +4,13 @@
 Categorical likelihood is to be used if we assume that the 
 uncertainity associated with the data follows a Categorical distribution.
 ```math
-    p(y|f_1, f_2, \\dots, f_n) = Categorical(y | softmax(f_1, f_2, \\dots, f_n))
+    p(y|f_1, f_2, \\dots, f_{n-1}) = Categorical(y | softmax(f_1, f_2, \\dots, f_{n-1}, 0))
 ```
 On calling, this would return a Categorical distribution with `f_i` 
 probability of `i` category.
 """
 struct CategoricalLikelihood end
 
-(l::CategoricalLikelihood)(f::AbstractVector{<:Real}) = Categorical(softmax(f))
+(l::CategoricalLikelihood)(f::AbstractVector{<:Real}) = Categorical(softmax(append!(f, 0)))
 
-(l::CategoricalLikelihood)(fs::AbstractVector) = Product(Categorical.(softmax.(fs)))
+(l::CategoricalLikelihood)(fs::AbstractVector) = Product(Categorical.(softmax.(append!.(fs, 0))))

--- a/test/likelihoods/categorical.jl
+++ b/test/likelihoods/categorical.jl
@@ -15,6 +15,7 @@
     y = [Y[[i + j*N for j in 0:(OUT_DIM - 1)]] for i in 1:N]
     # Replace with mo_inverse_transform once it is merged
 
+    @test length(lik(rand(3)).p) == 4
     @test lik(y) isa Distribution
     @test length(rand(rng, lik(y))) == 10
     @test Functors.functor(lik)[1] == ()

--- a/test/likelihoods/categorical.jl
+++ b/test/likelihoods/categorical.jl
@@ -15,7 +15,7 @@
     y = [Y[[i + j*N for j in 0:(OUT_DIM - 1)]] for i in 1:N]
     # Replace with mo_inverse_transform once it is merged
 
-    @test typeof(lik(y)) <: Distribution
+    @test lik(y) isa Distribution
     @test length(rand(rng, lik(y))) == 10
     @test Functors.functor(lik)[1] == ()
 end

--- a/test/likelihoods/categorical.jl
+++ b/test/likelihoods/categorical.jl
@@ -1,0 +1,21 @@
+@testset "CategoricalLikelihood" begin
+    rng = MersenneTwister(123)
+    gp = GP(IndependentMOKernel(SqExponentialKernel()))
+    IN_DIM = 3
+    OUT_DIM = 4
+    N = 10
+    x = [rand(rng, IN_DIM) for _=1:N]
+    X = MOInput(x, OUT_DIM)
+    lik = CategoricalLikelihood()
+    lgp = LatentGP(gp, lik, 1e-5)
+    lfgp = lgp(X)
+
+    Y = rand(rng, lfgp.fx)
+    
+    y = [Y[[i + j*N for j in 0:(OUT_DIM - 1)]] for i in 1:N]
+    # Replace with mo_inverse_transform once it is merged
+
+    @test typeof(lik(y)) <: Distribution
+    @test length(rand(rng, lik(y))) == 10
+    @test Functors.functor(lik)[1] == ()
+end

--- a/test/likelihoods/gaussian.jl
+++ b/test/likelihoods/gaussian.jl
@@ -7,7 +7,7 @@
     lgp = LatentGP(gp, lik, 1e-5)
     lfgp = lgp(x)
 
-    @test typeof(lik(rand(rng, lfgp.fx))) <: Distribution
+    @test lik(rand(rng, lfgp.fx)) isa Distribution
     @test length(rand(rng, lik(rand(rng, lfgp.fx)))) == 10
     @test keys(Functors.functor(lik)[1]) == (:σ²,)
 end

--- a/test/likelihoods/poisson.jl
+++ b/test/likelihoods/poisson.jl
@@ -7,7 +7,7 @@
     lgp = LatentGP(gp, lik, 1e-5)
     lfgp = lgp(x)
     
-    @test typeof(lik(rand(rng, lfgp.fx))) <: Distribution
+    @test lik(rand(rng, lfgp.fx)) isa Distribution
     @test length(rand(rng, lik(rand(rng, lfgp.fx)))) == 10
     @test Functors.functor(lik)[1] == ()
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using Distributions
 @testset "GPLikelihoods.jl" begin
 
     @testset "likelihoods" begin
+        include("likelihoods/categorical.jl")
         include("likelihoods/gaussian.jl")
         include("likelihoods/poisson.jl")
     end


### PR DESCRIPTION
Adds categorical likelihood. This can be used along with `MOInput`s and `MOKernel`s to model multi-class classification.