### PR TITLE
Update construction MvNormal in Heteroscedastic

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GPLikelihoods"
 uuid = "6031954c-0455-49d7-b3b9-3e1c99afaf40"
 authors = ["JuliaGaussianProcesses Team"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/GPLikelihoods.jl
+++ b/src/GPLikelihoods.jl
@@ -2,6 +2,7 @@ module GPLikelihoods
 
 using Distributions
 using Functors
+using LinearAlgebra
 using Random
 using StatsFuns
 

--- a/src/likelihoods/gaussian.jl
+++ b/src/likelihoods/gaussian.jl
@@ -21,19 +21,19 @@ GaussianLikelihood(σ²::Real) = GaussianLikelihood([σ²])
 
 (l::GaussianLikelihood)(f::Real) = Normal(f, sqrt(first(l.σ²)))
 
-(l::GaussianLikelihood)(fs::AbstractVector{<:Real}) = MvNormal(fs, sqrt(first(l.σ²)))
+(l::GaussianLikelihood)(fs::AbstractVector{<:Real}) = MvNormal(fs, first(l.σ²) * I)
 
 """
     HeteroscedasticGaussianLikelihood(l::AbstractLink=ExpLink())
 
 Heteroscedastic Gaussian likelihood. 
-This is a Gaussian likelihood whose mean and the log of whose variance are functions of the
-latent process.
+This is a Gaussian likelihood whose mean and variance are functions of
+latent processes.
 
 ```math
-    p(y|[f, g]) = Normal(y | f, l(g))
+    p(y|[f, g]) = Normal(y | f, sqrt(l(g)))
 ```
-On calling, this would return a normal distribution with mean `f` and std. dev. `l(g)`.
+On calling, this would return a normal distribution with mean `f` and variance `l(g)`.
 Where `l` is link going from R to R^+
 """
 struct HeteroscedasticGaussianLikelihood{Tl<:AbstractLink}
@@ -43,7 +43,7 @@ end
 HeteroscedasticGaussianLikelihood() = HeteroscedasticGaussianLikelihood(ExpLink())
 
 function (l::HeteroscedasticGaussianLikelihood)(f::AbstractVector{<:Real})
-    return Normal(f[1], l.invlink(f[2]))
+    return Normal(f[1], sqrt(l.invlink(f[2])))
 end
 
 function (l::HeteroscedasticGaussianLikelihood)(fs::AbstractVector)

--- a/src/likelihoods/gaussian.jl
+++ b/src/likelihoods/gaussian.jl
@@ -47,5 +47,5 @@ function (l::HeteroscedasticGaussianLikelihood)(f::AbstractVector{<:Real})
 end
 
 function (l::HeteroscedasticGaussianLikelihood)(fs::AbstractVector)
-    return MvNormal(first.(fs), l.invlink.(last.(fs)) * I)
+    return MvNormal(first.(fs), Diagonal(l.invlink.(last.(fs))))
 end

--- a/src/likelihoods/gaussian.jl
+++ b/src/likelihoods/gaussian.jl
@@ -47,5 +47,5 @@ function (l::HeteroscedasticGaussianLikelihood)(f::AbstractVector{<:Real})
 end
 
 function (l::HeteroscedasticGaussianLikelihood)(fs::AbstractVector)
-    return MvNormal(first.(fs), l.invlink.(last.(fs)))
+    return MvNormal(first.(fs), l.invlink.(last.(fs)) * I)
 end


### PR DESCRIPTION
Following a warning in the docs, the constructor of `MvNormal` has been changed
I also changed that the transform leads to the variance and not the std. dev. (which is more standard in the literature)
There was also a bug for the homoscedastic case (taking the std. dev. instead of the variance)