### PR TITLE
Get rid of joinpath

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GPLikelihoods"
 uuid = "6031954c-0455-49d7-b3b9-3e1c99afaf40"
 authors = ["JuliaGaussianProcesses Team"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/GPLikelihoods.jl
+++ b/src/GPLikelihoods.jl
@@ -30,11 +30,11 @@ export Link,
 include("links.jl")
 
 # Likelihoods
-include(joinpath("likelihoods", "bernoulli.jl"))
-include(joinpath("likelihoods", "categorical.jl"))
-include(joinpath("likelihoods", "gaussian.jl"))
-include(joinpath("likelihoods", "poisson.jl"))
-include(joinpath("likelihoods", "gamma.jl"))
-include(joinpath("likelihoods", "exponential.jl"))
+include("likelihoods/bernoulli.jl")
+include("likelihoods/categorical.jl")
+include("likelihoods/gaussian.jl")
+include("likelihoods/poisson.jl")
+include("likelihoods/gamma.jl")
+include("likelihoods/exponential.jl")
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,12 +11,12 @@ using StatsFuns
     include("test_utils.jl")
     include("links.jl")    
     @testset "likelihoods" begin
-        include(joinpath("likelihoods", "bernoulli.jl"))
-        include(joinpath("likelihoods", "categorical.jl"))
-        include(joinpath("likelihoods", "gaussian.jl"))
-        include(joinpath("likelihoods", "poisson.jl"))
-        include(joinpath("likelihoods", "gamma.jl"))
-        include(joinpath("likelihoods", "exponential.jl"))
+        include("likelihoods/bernoulli.jl")
+        include("likelihoods/categorical.jl")
+        include("likelihoods/gaussian.jl")
+        include("likelihoods/poisson.jl")
+        include("likelihoods/gamma.jl")
+        include("likelihoods/exponential.jl")
     end
 
 end


### PR DESCRIPTION
Similarly to KF.jl and GP.jl joinpath confuses the lintering and is not needed/recommended