### PR TITLE
Add AbstractLikelihood type and use operatorname for docstrings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GPLikelihoods"
 uuid = "6031954c-0455-49d7-b3b9-3e1c99afaf40"
 authors = ["JuliaGaussianProcesses Team"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/GPLikelihoods.jl
+++ b/src/GPLikelihoods.jl
@@ -30,6 +30,7 @@ export Link,
 include("links.jl")
 
 # Likelihoods
+abstract type AbstractLikelihood end
 include("likelihoods/bernoulli.jl")
 include("likelihoods/categorical.jl")
 include("likelihoods/gaussian.jl")

--- a/src/likelihoods/bernoulli.jl
+++ b/src/likelihoods/bernoulli.jl
@@ -6,7 +6,7 @@ uncertainity associated with the data follows a Bernoulli distribution.
 The link `l` needs to transform the input `f` to the domain [0, 1]
 
 ```math
-    p(y|f) = \\mathrm{Bernoulli}(y | l(f))
+    p(y|f) = \\operatorname{Bernoulli}(y | l(f))
 ```
 On calling, this would return a Bernoulli distribution with `l(f)` probability of `true`.
 """

--- a/src/likelihoods/bernoulli.jl
+++ b/src/likelihoods/bernoulli.jl
@@ -6,11 +6,11 @@ uncertainity associated with the data follows a Bernoulli distribution.
 The link `l` needs to transform the input `f` to the domain [0, 1]
 
 ```math
-    p(y|f) = Bernoulli(y | l(f))
+    p(y|f) = \\mathrm{Bernoulli}(y | l(f))
 ```
 On calling, this would return a Bernoulli distribution with `l(f)` probability of `true`.
 """
-struct BernoulliLikelihood{Tl<:AbstractLink}
+struct BernoulliLikelihood{Tl<:AbstractLink} <: AbstractLikelihood
     invlink::Tl
 end
 

--- a/src/likelihoods/categorical.jl
+++ b/src/likelihoods/categorical.jl
@@ -4,9 +4,9 @@
 Categorical likelihood is to be used if we assume that the 
 uncertainity associated with the data follows a Categorical distribution.
 ```math
-    p(y|f_1, f_2, \\dots, f_{n-1}) = \\mathrm{Categorical}(y | l(f_1, f_2, \\dots, f_{n-1}, 0))
+    p(y|f_1, f_2, \\dots, f_{n-1}) = \\operatorname{Categorical}(y | l(f_1, f_2, \\dots, f_{n-1}, 0))
 ```
-Given an `AbstractVector` [f_1, f_2, ..., f_{n-1}], returns a `Categorical` distribution,
+Given an `AbstractVector` [f_1, f_2, ..., f_{n-1}]`, returns a `Categorical` distribution,
 with probabilities given by `l(f_1, f_2, ..., f_{n-1}, 0)`.
 """
 struct CategoricalLikelihood{Tl<:AbstractLink} <: AbstractLikelihood

--- a/src/likelihoods/categorical.jl
+++ b/src/likelihoods/categorical.jl
@@ -4,12 +4,12 @@
 Categorical likelihood is to be used if we assume that the 
 uncertainity associated with the data follows a Categorical distribution.
 ```math
-    p(y|f_1, f_2, \\dots, f_{n-1}) = Categorical(y | l(f_1, f_2, \\dots, f_{n-1}, 0))
+    p(y|f_1, f_2, \\dots, f_{n-1}) = \\mathrm{Categorical}(y | l(f_1, f_2, \\dots, f_{n-1}, 0))
 ```
 Given an `AbstractVector` [f_1, f_2, ..., f_{n-1}], returns a `Categorical` distribution,
 with probabilities given by `l(f_1, f_2, ..., f_{n-1}, 0)`.
 """
-struct CategoricalLikelihood{Tl<:AbstractLink}
+struct CategoricalLikelihood{Tl<:AbstractLink} <: AbstractLikelihood
     invlink::Tl
 end
 

--- a/src/likelihoods/categorical.jl
+++ b/src/likelihoods/categorical.jl
@@ -6,8 +6,8 @@ uncertainity associated with the data follows a Categorical distribution.
 ```math
     p(y|f_1, f_2, \\dots, f_{n-1}) = \\operatorname{Categorical}(y | l(f_1, f_2, \\dots, f_{n-1}, 0))
 ```
-Given an `AbstractVector` [f_1, f_2, ..., f_{n-1}], returns a `Categorical` distribution,
-with probabilities given by `l(f_1, f_2, ..., f_{n-1}, 0)`.
+Given an `AbstractVector` ``[f_1, f_2, ..., f_{n-1}]``, returns a `Categorical` distribution,
+with probabilities given by ``l(f_1, f_2, ..., f_{n-1}, 0)``.
 """
 struct CategoricalLikelihood{Tl<:AbstractLink} <: AbstractLikelihood
     invlink::Tl

--- a/src/likelihoods/categorical.jl
+++ b/src/likelihoods/categorical.jl
@@ -6,7 +6,7 @@ uncertainity associated with the data follows a Categorical distribution.
 ```math
     p(y|f_1, f_2, \\dots, f_{n-1}) = \\operatorname{Categorical}(y | l(f_1, f_2, \\dots, f_{n-1}, 0))
 ```
-Given an `AbstractVector` [f_1, f_2, ..., f_{n-1}]`, returns a `Categorical` distribution,
+Given an `AbstractVector` [f_1, f_2, ..., f_{n-1}], returns a `Categorical` distribution,
 with probabilities given by `l(f_1, f_2, ..., f_{n-1}, 0)`.
 """
 struct CategoricalLikelihood{Tl<:AbstractLink} <: AbstractLikelihood

--- a/src/likelihoods/exponential.jl
+++ b/src/likelihoods/exponential.jl
@@ -4,10 +4,10 @@
 Exponential likelihood with scale given by `l(f)`.
 
 ```math
-    p(y|f) = Exponential(y | l(f))
+    p(y|f) = \\mathrm{Exponential}(y | l(f))
 ```
 """
-struct ExponentialLikelihood{Tl<:AbstractLink}
+struct ExponentialLikelihood{Tl<:AbstractLink} <: AbstractLikelihood
     invlink::Tl
 end
 

--- a/src/likelihoods/exponential.jl
+++ b/src/likelihoods/exponential.jl
@@ -4,7 +4,7 @@
 Exponential likelihood with scale given by `l(f)`.
 
 ```math
-    p(y|f) = \\mathrm{Exponential}(y | l(f))
+    p(y|f) = \\operatorname{Exponential}(y | l(f))
 ```
 """
 struct ExponentialLikelihood{Tl<:AbstractLink} <: AbstractLikelihood

--- a/src/likelihoods/gamma.jl
+++ b/src/likelihoods/gamma.jl
@@ -4,11 +4,11 @@
 Gamma likelihood with fixed shape `α`.
 
 ```math
-    p(y|f) = Gamma(y | α, l(f))
+    p(y|f) = \\mathrm{Gamma}(y | α, l(f))
 ```
 On calling, this would return a gamma distribution with shape `α` and scale `l(f)`.
 """
-struct GammaLikelihood{T<:Real,Tl<:AbstractLink}
+struct GammaLikelihood{T<:Real,Tl<:AbstractLink} <: AbstractLikelihood
     α::T    # shape parameter
     invlink::Tl
 end

--- a/src/likelihoods/gamma.jl
+++ b/src/likelihoods/gamma.jl
@@ -4,7 +4,7 @@
 Gamma likelihood with fixed shape `α`.
 
 ```math
-    p(y|f) = \\mathrm{Gamma}(y | α, l(f))
+    p(y|f) = \\operatorname{Gamma}(y | α, l(f))
 ```
 On calling, this would return a gamma distribution with shape `α` and scale `l(f)`.
 """

--- a/src/likelihoods/gaussian.jl
+++ b/src/likelihoods/gaussian.jl
@@ -5,7 +5,7 @@ Gaussian likelihood with `σ²` variance. This is to be used if we assume that t
 uncertainity associated with the data follows a Gaussian distribution.
 
 ```math
-    p(y|f) = \\mathrm{Normal}(y | f, σ²)
+    p(y|f) = \\operatorname{Normal}(y | f, σ²)
 ```
 On calling, this would return a normal distribution with mean `f` and variance σ².
 """

--- a/src/likelihoods/gaussian.jl
+++ b/src/likelihoods/gaussian.jl
@@ -31,7 +31,7 @@ This is a Gaussian likelihood whose mean and variance are functions of
 latent processes.
 
 ```math
-    p(y|[f, g]) = \\mathrm{Normal}(y | f, sqrt(l(g)))
+    p(y|[f, g]) = \\operatorname{Normal}(y | f, sqrt(l(g)))
 ```
 On calling, this would return a normal distribution with mean `f` and variance `l(g)`.
 Where `l` is link going from R to R^+

--- a/src/likelihoods/gaussian.jl
+++ b/src/likelihoods/gaussian.jl
@@ -5,11 +5,11 @@ Gaussian likelihood with `σ²` variance. This is to be used if we assume that t
 uncertainity associated with the data follows a Gaussian distribution.
 
 ```math
-    p(y|f) = Normal(y | f, σ²)
+    p(y|f) = \\mathrm{Normal}(y | f, σ²)
 ```
 On calling, this would return a normal distribution with mean `f` and variance σ².
 """
-struct GaussianLikelihood{T<:Real}
+struct GaussianLikelihood{T<:Real} <: AbstractLikelihood
     σ²::Vector{T}
 end
 
@@ -31,12 +31,12 @@ This is a Gaussian likelihood whose mean and variance are functions of
 latent processes.
 
 ```math
-    p(y|[f, g]) = Normal(y | f, sqrt(l(g)))
+    p(y|[f, g]) = \\mathrm{Normal}(y | f, sqrt(l(g)))
 ```
 On calling, this would return a normal distribution with mean `f` and variance `l(g)`.
 Where `l` is link going from R to R^+
 """
-struct HeteroscedasticGaussianLikelihood{Tl<:AbstractLink}
+struct HeteroscedasticGaussianLikelihood{Tl<:AbstractLink} <: AbstractLikelihood
     invlink::Tl
 end
 

--- a/src/likelihoods/poisson.jl
+++ b/src/likelihoods/poisson.jl
@@ -4,13 +4,13 @@
 Poisson likelihood with rate defined as `l(f)`.
 
 ```math
-    p(y|f) = Poisson(y | θ=l(f))
+    p(y|f) = \\mathrm{Poisson}(y | θ=l(f))
 ```
 
 This is to be used if  we assume that the uncertainity associated
 with the data follows a Poisson distribution.
 """
-struct PoissonLikelihood{L<:AbstractLink}
+struct PoissonLikelihood{L<:AbstractLink} <: AbstractLikelihood
     invlink::L
 end
 

--- a/src/likelihoods/poisson.jl
+++ b/src/likelihoods/poisson.jl
@@ -4,7 +4,7 @@
 Poisson likelihood with rate defined as `l(f)`.
 
 ```math
-    p(y|f) = \\mathrm{Poisson}(y | θ=l(f))
+    p(y|f) = \\operatorname{Poisson}(y | θ=l(f))
 ```
 
 This is to be used if  we assume that the uncertainity associated

--- a/src/links.jl
+++ b/src/links.jl
@@ -94,7 +94,7 @@ Base.inv(::LogitLink) = LogisticLink()
 """
     LogisticLink()
 
-`exp(x)/(1+exp(-x))` link. f:ℝ->[0,1]. Its inverse is the [`Logit`](@ref).
+`exp(x)/(1+exp(-x))` link. f:ℝ->[0,1]. Its inverse is the [`LogitLink`](@ref).
 """
 struct LogisticLink <: AbstractLink end
 


### PR DESCRIPTION
Solves #45 by adding an `AbstractLikelihood` type and use `\mathrm` for the distribution names in math mode