### PR TITLE
Correct typo in `LogisticLink` docstring

### DIFF
--- a/src/links.jl
+++ b/src/links.jl
@@ -89,7 +89,7 @@ LogitLink() = Link(logit)
 """
     LogisticLink()
 
-`exp(x)/(1+exp(-x))` link. f:ℝ->[0,1]. Its inverse is the [`LogitLink`](@ref).
+`1/(1+exp(-x))` link. f:ℝ->[0,1]. Its inverse is the [`LogitLink`](@ref).
 """
 LogisticLink() = Link(logistic)
 


### PR DESCRIPTION
The formula should read exp(f)/(1+exp(f)) or 1/(1+exp(-f)). I chose the latter for simplicity.