### PR TITLE
Use smart `link` constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GPLikelihoods"
 uuid = "6031954c-0455-49d7-b3b9-3e1c99afaf40"
 authors = ["JuliaGaussianProcesses Team"]
-version = "0.2.6"
+version = "0.2.7"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/GPLikelihoods.jl
+++ b/src/GPLikelihoods.jl
@@ -14,7 +14,6 @@ export BernoulliLikelihood,
     PoissonLikelihood,
     ExponentialLikelihood,
     GammaLikelihood
-export link
 export Link,
     ChainLink,
     ExpLink,

--- a/src/GPLikelihoods.jl
+++ b/src/GPLikelihoods.jl
@@ -14,6 +14,7 @@ export BernoulliLikelihood,
     PoissonLikelihood,
     ExponentialLikelihood,
     GammaLikelihood
+export link
 export Link,
     ChainLink,
     ExpLink,

--- a/src/likelihoods/bernoulli.jl
+++ b/src/likelihoods/bernoulli.jl
@@ -14,7 +14,7 @@ struct BernoulliLikelihood{Tl<:AbstractLink} <: AbstractLikelihood
     invlink::Tl
 end
 
-BernoulliLikelihood(l=logistic) = BernoulliLikelihood(Link(l))
+BernoulliLikelihood(l=logistic) = BernoulliLikelihood(link(l))
 
 (l::BernoulliLikelihood)(f::Real) = Bernoulli(l.invlink(f))
 

--- a/src/likelihoods/categorical.jl
+++ b/src/likelihoods/categorical.jl
@@ -13,7 +13,7 @@ struct CategoricalLikelihood{Tl<:AbstractLink} <: AbstractLikelihood
     invlink::Tl
 end
 
-CategoricalLikelihood(l=softmax) = CategoricalLikelihood(Link(l))
+CategoricalLikelihood(l=softmax) = CategoricalLikelihood(link(l))
 
 (l::CategoricalLikelihood)(f::AbstractVector{<:Real}) = Categorical(l.invlink(vcat(f, 0)))
 

--- a/src/likelihoods/exponential.jl
+++ b/src/likelihoods/exponential.jl
@@ -11,7 +11,7 @@ struct ExponentialLikelihood{Tl<:AbstractLink} <: AbstractLikelihood
     invlink::Tl
 end
 
-ExponentialLikelihood(l=exp) = ExponentialLikelihood(Link(l))
+ExponentialLikelihood(l=exp) = ExponentialLikelihood(link(l))
 
 (l::ExponentialLikelihood)(f::Real) = Exponential(l.invlink(f))
 

--- a/src/likelihoods/gamma.jl
+++ b/src/likelihoods/gamma.jl
@@ -14,7 +14,7 @@ struct GammaLikelihood{T<:Real,Tl<:AbstractLink} <: AbstractLikelihood
 end
 
 GammaLikelihood(l) = GammaLikelihood(1.0, l)
-GammaLikelihood(α::Real=1.0, l=exp) = GammaLikelihood(α, Link(l))
+GammaLikelihood(α::Real=1.0, l=exp) = GammaLikelihood(α, link(l))
 
 @functor GammaLikelihood
 

--- a/src/likelihoods/gaussian.jl
+++ b/src/likelihoods/gaussian.jl
@@ -40,7 +40,7 @@ struct HeteroscedasticGaussianLikelihood{Tl<:AbstractLink} <: AbstractLikelihood
     invlink::Tl
 end
 
-HeteroscedasticGaussianLikelihood(l=exp) = HeteroscedasticGaussianLikelihood(Link(l))
+HeteroscedasticGaussianLikelihood(l=exp) = HeteroscedasticGaussianLikelihood(link(l))
 
 function (l::HeteroscedasticGaussianLikelihood)(f::AbstractVector{<:Real})
     return Normal(f[1], sqrt(l.invlink(f[2])))

--- a/src/likelihoods/poisson.jl
+++ b/src/likelihoods/poisson.jl
@@ -14,7 +14,7 @@ struct PoissonLikelihood{L<:AbstractLink} <: AbstractLikelihood
     invlink::L
 end
 
-PoissonLikelihood(l=exp) = PoissonLikelihood(Link(l))
+PoissonLikelihood(l=exp) = PoissonLikelihood(link(l))
 
 (l::PoissonLikelihood)(f::Real) = Poisson(l.invlink(f))
 

--- a/src/links.jl
+++ b/src/links.jl
@@ -23,7 +23,7 @@ struct Link{F} <: AbstractLink
     f::F
 end
 
-link(f) = Link{typeof(f)}(f)
+link(f) = Link(f)
 link(l::AbstractLink) = l
 
 (l::Link)(x) = l.f(x)

--- a/src/links.jl
+++ b/src/links.jl
@@ -23,6 +23,9 @@ struct Link{F} <: AbstractLink
     f::F
 end
 
+link(f) = Link{typeof(f)}(f)
+link(l::AbstractLink) = l
+
 (l::Link)(x) = l.f(x)
 
 Base.inv(l::Link) = Link(InverseFunctions.inverse(l.f))

--- a/test/links.jl
+++ b/test/links.jl
@@ -4,8 +4,11 @@
 
     # Generic link
     f = sin
-    l = Link(f)
+    l = link(f)
+    @test l == Link(f)
     @test l(x) == f(x)
+    l = link(ExpLink())
+    @test l == ExpLink()
 
     # Log
     l = LogLink()

--- a/test/links.jl
+++ b/test/links.jl
@@ -4,10 +4,10 @@
 
     # Generic link
     f = sin
-    l = link(f)
+    l = GPLikelihoods.link(f)
     @test l == Link(f)
     @test l(x) == f(x)
-    l = link(ExpLink())
+    l = GPLikelihoods.link(ExpLink())
     @test l == ExpLink()
 
     # Log


### PR DESCRIPTION
Right now all likelihood constructor are wrapping passed `AbstractLink` in another `Link`. Of course it still works but it adds an unnecessary layer of complexity.
I added the `link` smart constructor which wraps functions and functors in a `Link` and is the identity when passed an `AbstractLink`.