### PR TITLE
Use Turing Actions for Documenter site and Navbar

### DIFF
--- a/.github/workflows/DocNav.yml
+++ b/.github/workflows/DocNav.yml
@@ -1,49 +1,40 @@
-name: Add Navbar
+name: Rebuild docs with newest navbar
 
 on:
-  page_build:  # Triggers the workflow on push events to gh-pages branch
-  workflow_dispatch:  # Allows manual triggering
+  # 3:25 AM UTC every Sunday -- choose an uncommon time to avoid
+  # periods of heavy GitHub Actions usage
   schedule:
-    - cron: '0 0 * * 0'  # Runs every week on Sunday at midnight (UTC)
+    - cron: '25 3 * * 0'
+  # Whenever needed
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
-  add-navbar:
+  update-navbar:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+
     steps:
-      - name: Checkout gh-pages
+      - name: Checkout gh-pages branch
         uses: actions/checkout@v4
         with:
           ref: gh-pages
-          fetch-depth: 0
 
-      - name: Download insert_navbar.sh
+      - name: Insert navbar
+        uses: TuringLang/actions/DocsNav@main
+        with:
+          doc-path: '.'
+          navbar-url: https://raw.githubusercontent.com/JuliaGaussianProcesses/.github/refs/heads/main/DocumenterNavbar/JuliaGPNavbar.html
+
+      - name: Commit and push changes
         run: |
-          curl -O https://raw.githubusercontent.com/TuringLang/turinglang.github.io/main/assets/scripts/insert_navbar.sh
-          chmod +x insert_navbar.sh
-
-      - name: Update Navbar
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email github-actions[bot]@users.noreply.github.com
-
-          # Define the URL of the navbar to be used
-          NAVBAR_URL="https://raw.githubusercontent.com/TuringLang/turinglang.github.io/main/assets/scripts/JuliaGPNavbar.html"
-         
-          # Update all HTML files in the current directory (gh-pages root)
-          ./insert_navbar.sh . $NAVBAR_URL
-         
-          # Remove the insert_navbar.sh file
-          rm insert_navbar.sh
-         
-          # Check if there are any changes
           if [[ -n $(git status -s) ]]; then
-            git add .
-            git commit -m "Added navbar and removed insert_navbar.sh"
-            git push "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" gh-pages
+            git config user.name github-actions[bot]
+            git config user.email github-actions[bot]@users.noreply.github.com
+            git add -A
+            git commit -m "Update navbar (automated)"
+            git push
           else
             echo "No changes to commit"
           fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ on:
       - master
     tags: '*'
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   # Skip intermediate builds: always.
@@ -13,22 +14,19 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
-  build:
+  docs:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: '1'
-      - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-        env:
-          JULIA_PKG_SERVER: ''
-      - name: Build and deploy
+      - name: Build and deploy Documenter.jl docs
         env:
           GKSwstype: nul # turn off GR's interactive plotting for notebooks
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
-          JULIA_DEBUG: Documenter # Print `@debug` statements (https://github.com/JuliaDocs/Documenter.jl/issues/955)
-        run: julia --project=docs/ docs/make.jl
+        uses: TuringLang/actions/DocsDocumenter@main
+        with:
+          julia-version: '1'
+          navbar-url: https://raw.githubusercontent.com/JuliaGaussianProcesses/.github/refs/heads/main/DocumenterNavbar/JuliaGPNavbar.html

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,6 +6,6 @@ StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 
 [compat]
 Distributions = "0.25"
-Documenter = "0.25, 0.26, 0.27"
+Documenter = "1"
 GPLikelihoods = "0.4"
 StatsFuns = "0.9, 1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,9 +7,6 @@ makedocs(;
     pages=["Home" => "index.md", "API" => "api.md"],
     repo="https://github.com/JuliaGaussianProcesses/GPLikelihoods.jl/blob/{commit}{path}#L{line}",
     authors="JuliaGaussianProcesses organization",
-    strict=true,
     checkdocs=:exports,
     #doctestfilters=JuliaGPsDocs.DOCTEST_FILTERS,
 )
-
-deploydocs(; repo="github.com/JuliaGaussianProcesses/GPLikelihoods.jl", push_preview=true)


### PR DESCRIPTION
Until now docs were using old navbar injection script that breaks at many places. I have replaced it with Turing Actions and also updated docs workflow to use Turing Actions which supports adding navbar direectory.

I have also updated navbar design to support all Documenter themes and lets keep JuliaGP navbar in this org instead of Turing so I have added new it in `.github` repo: https://github.com/JuliaGaussianProcesses/.github/pull/4